### PR TITLE
Request creation simplified

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ You would need to import the needed classes for your request
 For native API request:
 ```cpp
 #import "PNNativeRequest.h"
-#import "PNNativeModel.h"
+#import "PNNativeAdModel.h"
 ```
 
 For image API request:
 
 ```cpp
 #import "PNImageRequest.h"
-#import "PNImageModel.h"
+#import "PNImageAdModel.h"
 ```
 
 All classes are described under the following namespace
@@ -49,7 +49,7 @@ You need to create and fill a request for the native or image API. You could use
 Remember that you should set URLParameters as described in the [pubnative wiki](https://pubnative.atlassian.net/wiki/display/PUB/API+Documentation#APIDocumentation-3.Request)
 
 ```cpp
-PNNativeRequest *request = new cocos2d::pubnative::PNNativeRequest();
+PNNativeRequest *request = cocos2d::pubnative::PNNativeRequest::create();
 request->setURLParameter("app_token", <PUBNATIVE_APP_TOKEN>);
 request->setURLParameter("bundle_id", <APP_BUNDLE_ID>);
 request->setURLParameter("os", <OS>);
@@ -57,7 +57,6 @@ request->setURLParameter("os_version", <OS_VERSION>);
 request->setURLParameter("device_model", <DEVICE_MODEL>);
 request->setReadyCallback(<CALLBACK_TARGET>, pubnative_callback_ready(<YOUR_CLASS>::<REQUEST_READY_CALLBACK>));
 request->requestAds();
-request->release();
 ```
 
 ### Ad Load

--- a/pubnative/request/PNAdRequest.cpp
+++ b/pubnative/request/PNAdRequest.cpp
@@ -120,6 +120,7 @@ void PNAdRequest::requestAds(void)
 void PNAdRequest::invokeFailCallback(string description)
 {
     string errorString = "Pubnative ERROR - " + description;
+    CCLOG("%s", errorString.c_str());
     invokeCallback(false);
 }
 

--- a/pubnative/request/PNAdRequest.h
+++ b/pubnative/request/PNAdRequest.h
@@ -45,15 +45,15 @@ namespace cocos2d
         {
             
         public:
-            PNAdRequest(void);
-            ~PNAdRequest(void);
-            
             CCArray* getAds();
             void setReadyCallback(CCObject *pTarget, Pubnative_Ready_Callback pSelector);
             void setURLParameter(std::string key, std::string value);
             void requestAds(void);
             
         protected:
+            PNAdRequest(void);
+            ~PNAdRequest(void);
+            
             typedef enum
             {
                 PNAdRequestType_Native,

--- a/pubnative/request/PNImageRequest.cpp
+++ b/pubnative/request/PNImageRequest.cpp
@@ -30,6 +30,13 @@ using namespace std;
 using namespace cocos2d;
 using namespace cocos2d::pubnative;
 
+PNImageRequest* PNImageRequest::create()
+{
+    PNImageRequest *pRequest = new PNImageRequest();
+    pRequest->autorelease();
+    return pRequest;
+}
+
 PNImageRequest::PNImageRequest(void) : PNAdRequest()
 {
     //Constructor

--- a/pubnative/request/PNImageRequest.h
+++ b/pubnative/request/PNImageRequest.h
@@ -38,11 +38,14 @@ namespace cocos2d
         class PNImageRequest : public PNAdRequest
         {
         public:
-            PNImageRequest(void);
-            ~PNImageRequest(void);
+            PNImageRequest* create();
             
         protected:
             PNModel* parseAd(std::string adJSON);
+            
+        private:
+            PNImageRequest(void);
+            ~PNImageRequest(void);
         };
     }
 }

--- a/pubnative/request/PNNativeRequest.cpp
+++ b/pubnative/request/PNNativeRequest.cpp
@@ -41,6 +41,13 @@ PNNativeRequest::~PNNativeRequest()
     //Destructor
 }
 
+PNNativeRequest* PNNativeRequest::create()
+{
+    PNNativeRequest *pRequest = new PNNativeRequest();
+    pRequest->autorelease();
+    return pRequest;
+}
+
 PNModel* PNNativeRequest::parseAd(string adJSON)
 {
     return PNNativeAdModel::createWithJSON(adJSON);

--- a/pubnative/request/PNNativeRequest.h
+++ b/pubnative/request/PNNativeRequest.h
@@ -38,12 +38,14 @@ namespace cocos2d
         class PNNativeRequest : public PNAdRequest
         {
         public:
+            static PNNativeRequest* create();
             
-            PNNativeRequest(void);
-            ~PNNativeRequest(void);
         protected:
             PNModel* parseAd(std::string adJSON);
+            
         private:
+            PNNativeRequest(void);
+            ~PNNativeRequest(void);
         };
     }
 }


### PR DESCRIPTION
This patch simplifies the process for request creation.
- Added create() method to PNNativeRequest and PNImageRequest that returns an autorelease initialized instance (so no need to manually release).
- This patch also fixes some problems with Readme file and prints any request error to the console for debugging purposes.
